### PR TITLE
add `c_isbot` in customdata

### DIFF
--- a/scenarios/speedbit/SpeedBitScenariosIndexFull19.json
+++ b/scenarios/speedbit/SpeedBitScenariosIndexFull19.json
@@ -4,6 +4,7 @@
     "orgName": "speedbit2",
     "timeBetweenVisits": 5,
     "defaultOriginLevel1": "default",
+    "randomCustomData": [{"apiname": "c_isbot", "values": ["true"]}],
     "randomGoodQueries": [],
     "randomBadQueries": [],
     "scenarios": [


### PR DESCRIPTION
To identify traffic from the UAbot more easily in the Visit browser.